### PR TITLE
Fixed conflicting actions and types

### DIFF
--- a/g3_metaconfig/param.py
+++ b/g3_metaconfig/param.py
@@ -1,6 +1,10 @@
-from typing import Any, Callable, Optional, List, Union, Tuple
+import logging
+from typing import Any, Callable, Optional, List, Union, Tuple, Generator
 
+import configargparse
 from pydantic import BaseModel, Extra
+
+log = logging.getLogger("g3-param")
 
 
 class Param(BaseModel, extra=Extra.allow):
@@ -17,6 +21,54 @@ class Param(BaseModel, extra=Extra.allow):
     dest: str = None
     env_var: str = None
 
-    def __init__(self, *args, **kwargs, ):
+    def __init__(self, *args, **kwargs):
+        name = kwargs.pop("name", None)
+
         super().__init__(**kwargs, )
         self.args = list(args)
+
+        self._name = name
+
+    def _iter(self, *args, **kwargs) -> Generator[Tuple[str, Any], None, None]:
+        exclude: set = kwargs.get("exclude", None) or set()
+        exclude.add("_name")
+        return super()._iter(*args, **kwargs)
+
+    def set_name(self, param_name: str):
+        self._name = param_name
+
+    def set_dest(self):
+        if not self.dest:
+            self.dest = self._name
+
+    def set_args(self, auto_replace_underscores_with_dashes: bool):
+        if not self.args:
+            cli_name = self._name.lower()
+            if auto_replace_underscores_with_dashes:
+                cli_name = cli_name.replace('_', '-')
+            self.args = [f"--{cli_name}"]
+
+    def set_env(self, env_prefix: Optional[str] = None):
+        if all([env_prefix is not None, self.env_var is None, ]):
+            self.env_var = f"{env_prefix}{self._name}".upper()
+
+    def set_type(self, auto_typing: bool, annotation: Optional[Any], parser: Union[configargparse.ArgParser, Any]):
+        # Checking auto_typing compatibility with selected action
+        if auto_typing and self.action is not None:
+            try:
+                action_class = parser._registry_get("action", self.action, self.action)
+                action_class(
+                    option_strings=self.args,
+                    type="test",
+                    **self.dict(exclude={"args", "action"}, exclude_unset=True),
+                )
+            except TypeError as e:
+                auto_typing = False
+                log.warning(
+                    f"Param '{self._name}' has action={self.action} "
+                    f"which leads to disabling Config.auto_typing for this variable"
+                )
+
+        if all([auto_typing, self.type is None, annotation is not None]):
+            if isinstance(annotation, type):
+                self.type = annotation

--- a/g3_metaconfig/param.py
+++ b/g3_metaconfig/param.py
@@ -17,34 +17,6 @@ class Param(BaseModel, extra=Extra.allow):
     dest: str = None
     env_var: str = None
 
-    def __init__(
-            self,
-            *args,
-            action: str = None,
-            nargs: Union[int, str] = None,
-            const: str = None,
-            default: Any = None,
-            type: Optional[Callable[[], Any]] = None,
-            choices: list = None,
-            required: bool = None,
-            help: str = None,
-            metavar: Union[str, Tuple[str]] = None,
-            dest: str = None,
-            env_var: str = None,
-            **kwargs,
-    ):
-        super().__init__(
-            action=action,
-            nargs=nargs,
-            const=const,
-            default=default,
-            type=type,
-            choices=choices,
-            required=required,
-            help=help,
-            metavar=metavar,
-            dest=dest,
-            env_var=env_var,
-            **kwargs,
-        )
+    def __init__(self, *args, **kwargs, ):
+        super().__init__(**kwargs, )
         self.args = list(args)

--- a/g3_metaconfig/param.pyi
+++ b/g3_metaconfig/param.pyi
@@ -1,5 +1,7 @@
-from typing import Union, Any, Optional, Callable, Tuple, List
-from pydantic import BaseModel, Extra
+from typing import Union, Any, Optional, Callable, Tuple, List, Generator
+
+import configargparse
+from pydantic import BaseModel, Extra, Field
 
 
 class Param(BaseModel, extra=Extra.allow):
@@ -16,9 +18,12 @@ class Param(BaseModel, extra=Extra.allow):
     dest: str = None
     env_var: str = None
 
+    _name = Field()
+
     def __init__(
             self,
             *args,
+            name: str = None,
             action: str = None,
             nargs: Union[int, str] = None,
             const: str = None,
@@ -31,4 +36,22 @@ class Param(BaseModel, extra=Extra.allow):
             dest: str = None,
             env_var: str = None,
             **kwargs, ):
+        ...
+
+    def _iter(self, *args, **kwargs) -> Generator[Tuple[str, Any], None, None]:
+        ...
+
+    def set_name(self, param_name: str):
+        ...
+
+    def set_dest(self):
+        ...
+
+    def set_args(self, auto_replace_underscores_with_dashes: bool):
+        ...
+
+    def set_env(self, env_prefix: Optional[str] = None):
+        ...
+
+    def set_type(self, auto_typing: bool, annotation: Any, parser: Union[configargparse.ArgParser, Any]):
         ...

--- a/g3_metaconfig/param.pyi
+++ b/g3_metaconfig/param.pyi
@@ -1,0 +1,34 @@
+from typing import Union, Any, Optional, Callable, Tuple, List
+from pydantic import BaseModel, Extra
+
+
+class Param(BaseModel, extra=Extra.allow):
+    args: List[Any] = None
+    action: str = None
+    nargs: Union[int, str] = None
+    const: str = None
+    default: Any = None
+    type: Optional[Callable[[], Any]] = None
+    choices: list = None
+    required: bool = None
+    help: str = None
+    metavar: Union[str, Tuple[str]] = None
+    dest: str = None
+    env_var: str = None
+
+    def __init__(
+            self,
+            *args,
+            action: str = None,
+            nargs: Union[int, str] = None,
+            const: str = None,
+            default: Any = None,
+            type: Optional[Callable[[], Any]] = None,
+            choices: list = None,
+            required: bool = None,
+            help: str = None,
+            metavar: Union[str, Tuple[str]] = None,
+            dest: str = None,
+            env_var: str = None,
+            **kwargs, ):
+        ...

--- a/g3_metaconfig/tests/test_all.py
+++ b/g3_metaconfig/tests/test_all.py
@@ -37,12 +37,18 @@ class G3Config(metaclass=G3ConfigMeta):
 
     count: int = Param("--count", help="Help yuorself", default=33)
     count2: int = Param()
-    count3: int = Param(default=100)
+    count3: int = Param(default=100, action="store")
     count4: int = Param(type=int_or_none, default="asdf")
+
     condition: bool = Param("-c", "--cond", env_var="TEST_COND")
+    condition2: bool = Param(action="store_true")
+
     text: str = None
+
     number: float = 3.52
+
     array: list = ["asdsssssss"]
+
     optional_unset: Optional[str] = None
     optional_with_value: Optional[str] = "asdsssssss"
     other_types: Dict[str, str] = None


### PR DESCRIPTION
# Changes
1. Fixed crash when Config.auto_typing=True with uncompatible Param.action is set (e.g. "store_true")
2. Moved Param setters inside it's class to free up space in metaclass logic
3. Added related tests